### PR TITLE
3 / 2 appears twice in the operators table

### DIFF
--- a/perl6intro.adoc
+++ b/perl6intro.adoc
@@ -229,7 +229,7 @@ say "Hello $name";   #Hello John Doe
 
 | / | Infix | Division | 3 / 2 | 1.5
 
-| div | Infix | Integer Division (rounds down) | 3 / 2 | 1
+| div | Infix | Integer Division (rounds down) | 3 div 2 | 1
 
 | % | Infix | Modulo | 7 % 4 | 3
 


### PR DESCRIPTION
Presumably the row for the div operator should have 3 div 2 as an example instead.