### PR TITLE
Fixed Wikipedia Salt hyperlink

### DIFF
--- a/perl6intro.adoc
+++ b/perl6intro.adoc
@@ -1992,7 +1992,7 @@ In order to run the `md5_hex()` function that creates hashes, we need to load th
 The `use` keyword loads the module for use in the script.
 
 WARNING: In practice MD5 hashing alone is not sufficient, because it is prone to dictionary attacks. +
-It should be combined with a salt https://en.wikipedia.org/wiki/Salt_(cryptography)
+It should be combined with a salt link:https://en.wikipedia.org/wiki/Salt_(cryptography)[https://en.wikipedia.org/wiki/Salt_(cryptography)].
 
 == Unicode
 


### PR DESCRIPTION
Using a more verbose link syntax because the regular syntax somehow leaves out the last parenthesis.