### PR TITLE
Provide a more usual way of setting a hash value.

### DIFF
--- a/perl6intro.adoc
+++ b/perl6intro.adoc
@@ -642,7 +642,7 @@ Some of the methods that can be called on hashes are:
 .`Script`
 ----
 my %capitals = (UK => 'London', Germany => 'Berlin');
-%capitals.push: (France => 'Paris');
+%capitals<France> = 'Paris';
 say %capitals.kv;
 say %capitals.keys;
 say %capitals.values;
@@ -658,7 +658,6 @@ The capital of France is: Paris
 ----
 
 .Explanation
-`.push: (key => 'Value')` adds a new key/value pair. +
 `.kv` returns a list containing all keys and values. +
 `.keys` returns a list that contains all keys. +
 `.values` returns a list that contains all values. +


### PR DESCRIPTION
People are more likely to use 
%HASH<key> = 'value' to set a key-value pair since repeatedly calling %HASH.push: (key => 'value') will end up creating an array of values for a key.