### PR TITLE
[EN] Fix a description of <:L+:N>

### DIFF
--- a/perl6intro.adoc
+++ b/perl6intro.adoc
@@ -2712,8 +2712,8 @@ if $email ~~ $regex {
 `<:L>+` matches one or more letters +
 `\.` matches a single [dot] character +
 `\@` matches a single [at] character +
-`<:L+:N>` matches at least one letter and a single number +
-`<:L+:N>+` matches one or more (letter(s) and number) +
+`<:L+:N>` matches a letter or a single number +
+`<:L+:N>+` matches one or more letters or numbers +
 
 The regex can be decomposed as following:
 


### PR DESCRIPTION
The `+` symbol in `<:L+:N>` doesn't mean multiple `<:L>`s, it means `set union`.
```
$ perl6 -e 'say "hello" ~~ /<:L+:N>/'
｢h｣
```

+ See also
  + https://docs.perl6.org/language/regexes#Unicode_properties