### PR TITLE
[ES] Change script file extensions to .p6

### DIFF
--- a/es.perl6intro.adoc
+++ b/es.perl6intro.adoc
@@ -2978,6 +2978,11 @@ gcc -c ncitest.c
 gcc -shared -o ncitest.dll ncitest.o
 ----
 
+.En MacOS:
+----
+gcc -dynamiclib -o libncitest.dylib ncitest.c
+----
+
 En la misma carpeta donde has compilado la librería en C, crea un nuevo archivo de Perl 6 que contenga el siguiente código y ejecútalo.
 
 [source,perl6]

--- a/es.perl6intro.adoc
+++ b/es.perl6intro.adoc
@@ -91,7 +91,7 @@ Descarga la versión de 32-bit o 64-bit dependiendo de tu arquitectura.
 
 Puedes ejecutar código Perl 6 mediante REPL (Read-Eval-Print Loop). Para ello, abre un terminal, introduce `perl6` y pulsa [Enter]. Aparecerá el prompt `>`. Ahora introduce una línea de código, pulsa [Enter] y aparecerá una línea nueva con el resultado. Puedes introducir otra línea o `exit` y pulsar [Enter] para salir al sistema.
 
-También puedes escribir tu código de Perl 6 en un archivo de texto, guardarlo y ejecutarlo. Es recomendable que el nombre de este archivo de texto tenga la extensión `.pl6`. Ejecuta el archivo de esta forma: `perl6 nombre-archivo.pl6` desde un terminal y pulsa [Enter]. La ejecución suele mostrar el resultado de sentencias como `say` para visualizar por la salida estándar contenidos de texto con un salto de línea al final .
+También puedes escribir tu código de Perl 6 en un archivo de texto, guardarlo y ejecutarlo. Es recomendable que el nombre de este archivo de texto tenga la extensión `.p6`. Ejecuta el archivo de esta forma: `perl6 nombre-archivo.p6` desde un terminal y pulsa [Enter]. La ejecución suele mostrar el resultado de sentencias como `say` para visualizar por la salida estándar contenidos de texto con un salto de línea al final .
 
 REPL normalmente se utiliza para probar trozos pequeños de código, como una línea. En el caso de programas con más de una línea de código es recomendable guardarlos en un archivo y ejecutarlos como hemos visto.
 
@@ -1186,17 +1186,17 @@ rmdir "carpeta-nueva";
 
 También puedes comprobar si una ruta existe y si es un archivo o una carpeta:
 
-Crea una carpeta vacía llamada `carpeta123`, un archivo vacío llamado `script123.pl6` y el siguiente script:
+Crea una carpeta vacía llamada `carpeta123`, un archivo vacío llamado `script123.p6` y el siguiente script:
 
 [source,perl6]
 ----
-say "script123.pl6".IO.e;
+say "script123.p6".IO.e;
 say "carpeta123".IO.e;
 
-say "script123.pl6".IO.d;
+say "script123.p6".IO.d;
 say "carpeta123".IO.d;
 
-say "script123.pl6".IO.f;
+say "script123.p6".IO.f;
 say "carpeta123".IO.f;
 ----
 
@@ -2289,7 +2289,7 @@ say "¿Qué haces hoy?"
 .`Salida`
 ----
 Type check failed in assignment to $nombre; expected Str but got Int
-  in block <unit> at exceptions.pl6 line 2
+  in block <unit> at exceptions.p6 line 2
 ----
 Debes tener en cuenta que cuando se produce un error (en este caso, debido a la asignación de un número a una variable de texto) el programa se interrumpirá y no evaluará cualquier otra línea de código.
 
@@ -2981,7 +2981,7 @@ gcc -shared -o ncitest.dll ncitest.o
 En la misma carpeta donde has compilado la librería en C, crea un nuevo archivo de Perl 6 que contenga el siguiente código y ejecútalo.
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 
@@ -3011,7 +3011,7 @@ Para hacerlo utilizamos `is symbol`.
 Vamos a modificar el script de Perl 6 que hemos visto de forma que la función de Perl 6 se llame `hola` en lugar de `holadesdec`.
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 
@@ -3039,7 +3039,7 @@ void holadesdec (char* nombre) {
 ----
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 
@@ -3063,7 +3063,7 @@ int suma (int a, int b) {
 ----
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 

--- a/perl6intro.adoc
+++ b/perl6intro.adoc
@@ -111,8 +111,8 @@ the value of the line.  You may then type another line, or type `exit`
 and hit [Enter] to leave the REPL.
 
 Alternatively, write your code in a file, save it and run it.
-It is recommended that Perl 6 scripts have a  `.pl6` file name extension.
-Run the file by typing `perl6 filename.pl6` into the terminal window
+It is recommended that Perl 6 scripts have a  `.p6` file name extension.
+Run the file by typing `perl6 filename.p6` into the terminal window
 and hitting [Enter]. Unlike the REPL, this will not automatically print
 the result of each line: the code must contain a statement like `say`
 to print output.
@@ -1219,17 +1219,17 @@ rmdir "newfolder";
 
 You can also check if a path exists; if it is a file; or a directory:
 
-In the directory where you will be running the below script, create an empty folder `folder123` and an empty pl6 file `script123.pl6`
+In the directory where you will be running the below script, create an empty folder `folder123` and an empty p6 file `script123.p6`
 
 [source,perl6]
 ----
-say "script123.pl6".IO.e;
+say "script123.p6".IO.e;
 say "folder123".IO.e;
 
-say "script123.pl6".IO.d;
+say "script123.p6".IO.d;
 say "folder123".IO.d;
 
-say "script123.pl6".IO.f;
+say "script123.p6".IO.f;
 say "folder123".IO.f;
 ----
 
@@ -2341,7 +2341,7 @@ say "How are you doing today?"
 .`Output`
 ----
 Type check failed in assignment to $name; expected Str but got Int
-   in block <unit> at exceptions.pl6:2
+   in block <unit> at exceptions.p6:2
 ----
 
 Notice that whenever an error occurs (in this case, assigning a number to a string variable) the program will stop and other lines of code will not be evaluated.
@@ -3047,7 +3047,7 @@ Within the same directory where you compiled your C library, create a new Perl 6
 file that contains the below code and run it.
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 
@@ -3081,7 +3081,7 @@ Lets modify the above Perl 6 script and rename the Perl 6 subroutine `hello`
 instead of `hellofromc`
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 
@@ -3111,7 +3111,7 @@ void hellofromc (char* name) {
 ----
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 
@@ -3136,7 +3136,7 @@ int add (int a, int b) {
 ----
 
 [source,perl6]
-.ncitest.pl6
+.ncitest.p6
 ----
 use NativeCall;
 

--- a/perl6intro.adoc
+++ b/perl6intro.adoc
@@ -3043,6 +3043,11 @@ gcc -c ncitest.c
 gcc -shared -o ncitest.dll ncitest.o
 ----
 
+.En MacOS:
+----
+gcc -dynamiclib -o libncitest.dylib ncitest.c
+----
+
 Within the same directory where you compiled your C library, create a new Perl 6
 file that contains the below code and run it.
 


### PR DESCRIPTION
It seems that majority of Perl 6 users prefer the .p6 extension. There
are some posts and discussion about it:
- https://www.reddit.com/r/perl6/comments/812cfa/pl_or_pl6/
- https://github.com/perl6/doc/issues/1807