### PR TITLE
[JA] Add MacOS C code compile example for NativeCall

### DIFF
--- a/ja.perl6intro.adoc
+++ b/ja.perl6intro.adoc
@@ -3031,6 +3031,11 @@ gcc -c ncitest.c
 gcc -shared -o ncitest.dll ncitest.o
 ----
 
+.On macOS:
+----
+gcc -dynamiclib -o libncitest.dylib ncitest.c
+----
+
 Cのライブラリをコンパイルしたのと同じディレクトリで、次のコードを含むPerl 6のファイルを作り、実行してください。
 
 [source,perl6]


### PR DESCRIPTION
This commit also contains:

- [JA] Fix typo (Jpanese version of En -> On in the English doc)