### PR TITLE
second update to  use the current Module Management Tool (Panda -> Zef)

### DIFF
--- a/de.perl6intro.adoc
+++ b/de.perl6intro.adoc
@@ -53,16 +53,21 @@ Perl 6 ist multi-paradigmatisch. Es unterstützt prozedurales, objektorientierte
 * *Perl 6*: Eine Sprachenspezifikation mit einer Testsuite. Implementierungen, die diese Tests bestehen nennt man Perl 6.
 * *Rakudo*: Ein Compiler für Perl 6.
 * *Rakudobrew*: Ein Installationenmanager für Rakudo.
-* *Panda*: Ein Perl 6 Moduleinstallierer.
-* *Rakudo Star*: Ein Paket mit Rakudo, Panda, einer Sammlung von Perl 6 Modulen und Dokumentation.
+* *Zef*: Ein Perl 6 Moduleinstallierer.
+* *Rakudo Star*: Ein Paket mit Rakudo, Zef, einer Sammlung von Perl 6 Modulen und Dokumentation.
 
 === Perl 6 installieren
 .Linux
-. Installiere Rakudobrew: https://github.com/tadzik/rakudobrew
 
-. Installiere Rakudo: Gebe dieses Kommando in ein Terminalfenster ein `rakudobrew build moar`
-
-. Installiere Panda: Gebe dieses Kommando in ein Terminalfenster ein `rakudobrew build panda`
+Um Rakudo-Star zu installieren, führe diese Kommandos in einem Terminalfenster aus:
+----
+wget https://rakudo.perl6.org/downloads/star/rakudo-star-2018.01.tar.gz
+tar xfz rakudo-star-2018.01.tar.gz
+cd rakudo-star-2018.01
+perl Configure.pl --gen-moar --prefix /opt/rakudo-star-2018.01
+make install
+----
+Mehr Informationen stehen unter: http://rakudo.org/how-to-get-rakudo/#Installing-Rakudo-Star-Linux
 
 .OSX
 Folgen Sie der Anleitung für Linux +
@@ -99,9 +104,9 @@ Rakudo Star beinhaltet einen Zeileineditor der dabei hilft, REPL leichter verwen
 Ist nur das einfache Rakudo aber nicht Rakudo Star installiert, dann sind wahrscheinlich keine Zeileneditorfunktionen aktiviert (Auf- und Abwärtspfeile für die Kommandozeilenhistorie, Links- und Rechtspfeil um die Eingabe zu bearbeite, Tabulator zur Vervollständigung).
 Das läßt sich mit einem der folgenden Kommandos nachholen:
 
-* `panda install Linenoise` funktioniert auf Windows, Linux und OSX
+* `zef install Linenoise` funktioniert auf Windows, Linux und OSX
 
-* `panda install Readline` funktioniert auf Linux, falls Sie die _Readline_-Bibliothek bevorzugen.
+* `zef install Readline` funktioniert auf Linux, falls Sie die _Readline_-Bibliothek bevorzugen.
 --
 
 === Editoren
@@ -2542,7 +2547,7 @@ Damit wird sichergestellt, dass auch wenn die Datenbank in falsche Hände gerate
 Lets say you need a script that generates the MD5 hash of a password in preparation for storing it in the DB.
 
 Zum Glück gibt es schon ein Perl 6 Modul, das den MD5 Algorithmus implementiert. Zeit es zu installieren: +
-`panda install Digest::MD5`
+`zef install Digest::MD5`
 
 Dann das folgende Skript ausführen:
 [source,perl6]


### PR DESCRIPTION
I forgot some changes: I hope now all substitutions of 'panda' -> 'zef' are now done. Also an update of the linux installation section is included.